### PR TITLE
Update README to be clearer about AndroidExplicitCrunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,13 @@ I highly recommend utilizing the Linker for Release Configuration builds; `Link 
 
 ![Android CSProj File](./Images/AndroidExplicitCrunch.png)
 
+_NOTE: This is an experimental setting!_
+
 - Add [`AndroidExplicitCrunch`](https://developer.xamarin.com/guides/android/under_the_hood/build_process/#Resource_Properties) to the Droid `csproj` file
   - When this property is set, the build process pre-crunches the .png files
   - Requires Xamarin.Android 7.0+
-  - If you are building an app with a very large number of local drawables, an initial build (or rebuild) can take minutes to complete. To speed up the build process, set `AndroidExplicitCrunch` property to `true` in the `csproj` file
+  - If you are building an app with a very large number of local drawables, an initial build (or rebuild) can take minutes to complete. To speed up the build process, set `AndroidExplicitCrunch` property to `true` in the `csproj` file.
+  - It is not known if this setting will truly speed up your build. Time your initial build, and then a second build with no changes. Make the call if the setting helps your app or not.
 
 
 # Project References


### PR DESCRIPTION
Hey @brminnick, I'm finding developers are turning on `AndroidExplicitCrunch` without the full picture: knowing it's experimental and it may/may not help their build times.

Can we make the proposed change? Thanks.